### PR TITLE
turret efficiency

### DIFF
--- a/interface/cockpit/cockpit.config.patch
+++ b/interface/cockpit/cockpit.config.patch
@@ -1,10 +1,11 @@
 [
-  {
-    "op": "add",
-    "path": "/displayDungeons/surfaceshellguarddungeons",
-    "value": {
-      "description": "According to intercepted unencrypted radio signals, it's a Shellguard outpost.",
-      "icon": "/interface/cockpit/dungeons/shellguard.png"
-    }
-  }
+	[
+		{"op":"test","path":"/displayDungeons","inverse":true},
+		{"op":"add","path":"/displayDungeons","value":{}}
+	],
+	[
+		{"op":"test","path":"/displayDungeons"},
+		{"op": "add","path": "/displayDungeons/surfaceshellguarddungeons","value": {"description": "According to intercepted unencrypted radio signals, it's a Shellguard outpost.","icon": "/interface/cockpit/dungeons/shellguard.png"}}
+  
+	]
 ]

--- a/interface/cockpit/cockpit.config.patch
+++ b/interface/cockpit/cockpit.config.patch
@@ -1,9 +1,5 @@
 [
 	[
-		{"op":"test","path":"/displayDungeons","inverse":true},
-		{"op":"add","path":"/displayDungeons","value":{}}
-	],
-	[
 		{"op":"test","path":"/displayDungeons"},
 		{"op": "add","path": "/displayDungeons/surfaceshellguarddungeons","value": {"description": "According to intercepted unencrypted radio signals, it's a Shellguard outpost.","icon": "/interface/cockpit/dungeons/shellguard.png"}}
   

--- a/objects/sgturrets/gvturret.lua
+++ b/objects/sgturrets/gvturret.lua
@@ -384,13 +384,17 @@ end
 -- Coroutine
 function findTarget()
   local nearEntities = world.entityQuery(self.basePosition, self.targetQueryRange, { includedTypes = { "monster", "npc", "player" } })
+  
+  
   return util.find(nearEntities, function(entityId)
     local targetPosition = world.entityPosition(entityId)
-        
-    if not entity.isValidTarget(entityId) or world.lineTileCollision(self.basePosition, targetPosition) then return false end
-
     local toTarget = world.distance(targetPosition, self.basePosition)
-    local targetAngle = math.atan(toTarget[2], object.direction() * toTarget[1])
-    return world.magnitude(toTarget) > self.targetMinRange and math.abs(targetAngle) < self.targetAngleRange
+	local targetAngle = math.atan(toTarget[2], object.direction() * toTarget[1])
+	
+	if (not entity.isValidTarget(entityId)) or (math.abs(targetAngle) > self.targetAngleRange) or (world.magnitude(toTarget) < self.targetMinRange) or (world.lineTileCollision(self.basePosition, targetPosition)) then
+		return false
+	end
+
+    return true
   end)
 end


### PR DESCRIPTION
order matters in this case. running too many tile collision checks needlessly impacts performance, especially with the 1800 range on the PDD. So now, turrets will first check if it's a valid target, then if it's in firing angle, them the min distance, then if all those are okay it does tile collision.