### PR TITLE
frackin universe racial bonus disabling property

### DIFF
--- a/instance_worlds.config.patch
+++ b/instance_worlds.config.patch
@@ -2512,6 +2512,9 @@
       "seed" : 1234,
       "beamUpRule" : "Anywherewithwarning",
       "disableDeathDrops" : true,
+      "worldProperties" : {
+        "frnpcoverride" : false
+      },
 
     "skyParameters" : {
       "spaceLevel" : 3000,
@@ -2582,6 +2585,9 @@
       "seed" : 1234,
       "beamUpRule" : "Anywherewithwarning",
       "disableDeathDrops" : true,
+      "worldProperties" : {
+        "frnpcoverride" : false
+      },
 
     "skyParameters" : {
       "spaceLevel" : 3000,
@@ -2652,6 +2658,9 @@
       "seed" : 1234,
       "beamUpRule" : "Anywherewithwarning",
       "disableDeathDrops" : true,
+      "worldProperties" : {
+        "frnpcoverride" : false
+      },
 
     "skyParameters" : {
       "spaceLevel" : 3000,


### PR DESCRIPTION
Implemented a world property in toy arena instances, which when using FU (not FR, sadly), will result in the npcs not having any racial traits. This addresses the fact that many toy weapons are rendered useless by the human racial bonus of 0.2 grit.